### PR TITLE
Add Pillow compatibility.

### DIFF
--- a/demo/simple_tk.py
+++ b/demo/simple_tk.py
@@ -66,7 +66,10 @@ class MainWindow(Frame, TwainBase):
 
     def DisplayImage(self, filename):
         try:
-            import ImageTk # PIL required
+            import ImageTk  # PIL required
+        except ImportError:
+            from PIL import ImageTk
+        try:
             imagedata = ImageTk.PhotoImage(file=filename)
             self.imageLabel.config(image=imagedata)
             self.imageLabel.pack(side="left", fill="both", expand=1)

--- a/src/twain.py
+++ b/src/twain.py
@@ -2031,7 +2031,10 @@ class Source(object):
             if rv == TWRC_CANCEL:
                 raise excDSTransferCancelled
             if ext != '.bmp':
-                import Image
+                try:
+                    import Image
+                except ImportError:
+                    from PIL import Image
                 Image.open(bmppath).save(filepath)            
                 os.remove(bmppath)
             after(more)
@@ -2527,7 +2530,10 @@ def dib_to_xbm_file(handle, path=None):
     handle, bmppath = tempfile.mkstemp('.bmp')
     os.close(handle)
     dib_to_bm_file(handle, bmppath)
-    import Image
+    try:
+        import Image
+    except ImportError:
+        from PIL import Image
     Image.open(bmppath).save(path, 'xbm')
     os.remove(bmppath)
 


### PR DESCRIPTION
Pillow >= 1.0 no longer supports “import Image”. So, fall back to using “from PIL import Image” on ImportError.